### PR TITLE
Add CLAUDE GitHub Actions and project documentation

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+GreerCoin is an ERC20-compliant Ethereum token with an ICO (Initial Coin Offering) demo. The repo has two parts:
+
+1. **Smart contracts** (root) — Solidity contracts compiled and deployed via Truffle
+2. **Frontend** (`client/`) — React app that interacts with the deployed contracts via Web3/MetaMask
+
+## Commands
+
+### Smart Contracts (run from root)
+```bash
+# Compile contracts
+truffle compile
+
+# Run contract tests
+truffle test
+
+# Run a single test file
+truffle test test/GreercoinTest.js
+
+# Deploy to local Ganache (port 7545)
+truffle migrate --network develop
+
+# Deploy to Ropsten or Mainnet (requires .env)
+truffle migrate --network ropsten
+truffle migrate --network mainnet
+```
+
+### Frontend (run from `client/`)
+```bash
+yarn start    # Start dev server
+yarn build    # Production build
+yarn test     # Run React tests
+```
+
+## Architecture
+
+### Smart Contracts
+
+- `contracts/GreerCoin.sol` — ERC20 token implementation (manual, no OpenZeppelin). Implements `transfer`, `transferFrom`, and `approve`/`allowance`.
+- `contracts/GreerCoinSale.sol` — ICO sale contract. Admin deploys it with a reference to the GreerCoin contract and a token price (in wei). Buyers call `buyTokens(n)` sending exact ETH. Admin can call `endSale()` to recover remaining tokens and ETH.
+- `migrations/2_deploy_contracts.js` — Reads config from `constants.js` (not committed; contains `name`, `symbol`, `decimals`, `standard`, and `test`/`prod` supply/price args). Deploys GreerCoin then GreerCoinSale, then transfers `icoSupply` tokens to the sale contract.
+- Compiled ABIs are output to `client/src/contracts/` (configured in `truffle-config.js`).
+
+### Frontend
+
+- **Entry**: `client/src/App.js` — Sets up React Router with two routes: `/` (Landing/ICO page) and `/about`.
+- **Web3 integration**: All blockchain logic lives in `client/src/components/landing/index.js`. It detects MetaMask (`window.ethereum`), instantiates Web3, loads contract instances from the ABI JSONs in `client/src/contracts/`, and reads/writes contract state. The component uses boolean "flag" state variables (e.g., `loadDataFlag`, `loadContractsFlag`) to coordinate async effects rather than calling async functions directly in effects.
+- **Layout system**: `client/src/hooks/index.js` exports `useLayout`, a hook that computes responsive breakpoints (`xs/sm/md/lg/xl`) from window width. The result is provided via `LayoutContext` and consumed throughout to apply CSS class names (using `classnames`).
+- **Modals**: `client/src/components/modals/` — A generic `Modal` wrapper with three content variants: `connection` (MetaMask connect flow), `purchase` (buy tokens form), `confirmation` (post-purchase tx hash display).
+- **Styling**: SCSS modules per component. Global constants in `client/src/constants.scss`.
+- **Absolute imports**: `client/jsconfig.json` sets `baseUrl` to `src/`, so imports like `components/button` resolve from `src/`.
+
+### Environment & Networks
+
+- Truffle networks: `develop` (Ganache, port 7545), `ropsten`, `mainnet`
+- `.env` file (not committed) must provide `MNENOMIC_MAINNET`, `MNENOMIC_ROPSTEN`, and `INFURA_API_KEY`
+- A `constants.js` file (not committed) at the root provides token metadata and supply/price parameters
+- Deployed to Firebase Hosting (`client/firebase.json`, `client/.firebaserc`)


### PR DESCRIPTION
Add developer guide documenting project architecture, build/test/deploy commands, and key design patterns (Web3 integration, layout system, modal structure) to help future contributors onboard quickly.   